### PR TITLE
Publish sha versioned images on each push

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,15 +12,30 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Docker Login
-      env:
-        DOCKER_USER: ${{secrets.DOCKER_USER}}
-        DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
-      run: |
-        docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
-    - name: Build the Docker image
-      run: |
-        docker build . --file Dockerfile --tag ${{secrets.DOCKER_USER}}/theinfinitewebpage:latest
-    - name: Docker Push
-      run: |
-        docker push ${{secrets.DOCKER_USER}}/theinfinitewebpage:latest
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USER }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Docker meta
+      id: docker_meta
+      uses: docker/metadata-action@v4
+      with:
+        images: |
+          ${{ secrets.DOCKER_USER }}/theinfinitewebpage
+        flavor: |
+          latest=true
+        tags: |
+          type=sha
+
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: Dockerfile
+        tags: ${{ steps.docker_meta.outputs.tags }}
+        labels: ${{ steps.docker_meta.outputs.labels }}
+        push: true


### PR DESCRIPTION
* this should publish `latest` tag AND `sha-xyz` tag on each push to the `main` branch so you will have fully versioned images